### PR TITLE
Sponsor.py works on Unix-y systems

### DIFF
--- a/Objs/Sponsors/Sponsor.py
+++ b/Objs/Sponsors/Sponsor.py
@@ -3,11 +3,12 @@
 from __future__ import division
 from ..Contestants.Contestant import Contestant
 import json
+import os
 import random
 from ..Sponsors.Traits import Traits
 from Objs.Utilities.ArenaUtils import JSONOrderedLoad
 
-TRAIT_FILE_PATH = 'Objs\Sponsors\Traits.json'
+TRAIT_FILE_PATH = os.path.join('Objs', 'Sponsors', 'Traits.json')
 with open(TRAIT_FILE_PATH) as TRAIT_FILE:
     RANDOM_TRAITS = JSONOrderedLoad(TRAIT_FILE)["Traits"]
 


### PR DESCRIPTION
Fixes the following error on OS X:
```
FileNotFoundError: [Errno 2] No such file or directory: 'Objs\\Sponsors\\Traits.json'
```